### PR TITLE
Added "readln" and "writeln" to grammar list

### DIFF
--- a/grammars/pascal.cson
+++ b/grammars/pascal.cson
@@ -13,7 +13,7 @@
 'name': 'Pascal'
 'patterns': [
   {
-    'match': '\\b(?i:(absolute|abstract|all|and|and_then|array|as|asm|attribute|begin|bindable|case|class|const|contains|default|div|do|do|else|end|except|export|exports|external|far|file|finalization|finally|for|forward|generic|goto|if|implementation|implements|import|in|index|inherited|initialization|interface|interrupt|is|label|library|mod|module|name|near|nil|not|object|of|only|operator|or|or_else|otherwise|override|package|packed|pow|private|program|property|protected|public|published|qualified|raise|read|record|repeat|resident|requires|resourcestring|restricted|segment|set|shl|shr|specialize|stored|then|threadvar|to|try|type|unit|until|uses|value|var|view|virtual|dynamic|overload|reintroduce|while|with|write|xor))\\b'
+    'match': '\\b(?i:(absolute|abstract|all|and|and_then|array|as|asm|attribute|begin|bindable|case|class|const|contains|default|div|do|do|else|end|except|export|exports|external|far|file|finalization|finally|for|forward|generic|goto|if|implementation|implements|import|in|index|inherited|initialization|interface|interrupt|is|label|library|mod|module|name|near|nil|not|object|of|only|operator|or|or_else|otherwise|override|package|packed|pow|private|program|property|protected|public|published|qualified|raise|read|readln|record|repeat|resident|requires|resourcestring|restricted|segment|set|shl|shr|specialize|stored|then|threadvar|to|try|type|unit|until|uses|value|var|view|virtual|dynamic|overload|reintroduce|while|with|write|writeln|xor))\\b'
     'name': 'keyword.control.pascal'
   }
   {


### PR DESCRIPTION
As above, `readln` and `writeln` are used a lot and also `read` and `write` are highlighted so to keep it consistent it's a good idea to highlight them.